### PR TITLE
device send back response only if recognize sender

### DIFF
--- a/core/src/main/java/com/uniquid/core/Listener.java
+++ b/core/src/main/java/com/uniquid/core/Listener.java
@@ -51,10 +51,10 @@ public class Listener implements Runnable {
                     FunctionResponseMessage response = handler.handleMessage(parentSimplifier, request);
                     if (response != null) {
                         endPoint.setResponse(response);
+                        endPoint.flush();
                     }
                 }
 
-                endPoint.flush();
             }
 
         } catch (InterruptedException e) {


### PR DESCRIPTION
If a device receives a request from an unknown sender, device must not respond